### PR TITLE
Update hyperlink to ITSG public key directory.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.6.2
  
 Package: tinyheb
 Architecture: all
-Depends: ${shlibs:Depends}, gs | ghostscript, perl, openssl, libdbi-perl, libdbd-mysql-perl, libdate-calc-perl, libemail-mime-encodings-perl, perl-tk, libmail-sender-perl (>=0.8.22), libpostscript-simple-perl (>=0.07), mysql-server, apache2 | httpd, libcompress-zlib-perl, libmozilla-ca-perl, libio-socket-ssl-perl
+Depends: ${shlibs:Depends}, gs | ghostscript, perl, openssl, libdbi-perl, libdbd-mysql-perl, libdate-calc-perl, libemail-mime-encodings-perl, perl-tk, libmail-sender-perl (>=0.8.22), libpostscript-simple-perl (>=0.07), mysql-server, apache2 | httpd, libcompress-zlib-perl, libio-socket-ssl-perl (>=1.53), libnet-ssleay-perl (>=1.42)
 Recommends: apache2, ntp
 Description: Billingsoftware for German midwives
  tinyHeb is a Web application for midwives in Germany to do the legal 

--- a/src/edifact/xauftrag.pl
+++ b/src/edifact/xauftrag.pl
@@ -30,9 +30,6 @@ use Tk::ItemStyle;
 use Tk::DialogBox;
 
 #use Data::Dumper;
-use Mozilla::CA;
-use IO::Socket::SSL;
-IO::Socket::SSL::set_ctx_defaults( SSL_ca_file => Mozilla::CA::SSL_ca_file(), );
 
 use Mail::Sender;
 use File::stat;

--- a/src/rechnung/ps2html.pl
+++ b/src/rechnung/ps2html.pl
@@ -253,50 +253,38 @@ if ($test_ind && $test_ind==2) {
 }
 
 
-# in Browser schreiben, falls Windows wird PDF erzeugt, sonst Postscript
+# in Browser schreiben als PDF
 my $all_rech=$p->get();
 
-#warn "User_agent: ",$q->user_agent;
-#warn "OS :",$^O;
-
-if ($q->user_agent !~ /Windows/ && $q->user_agent !~ /Macintosh/) {
-  my $filename = tiny_string_helpers::string2filename("Rechnung_${nachname}_${rechnungsnr}.ps");
-  print $q->header ( -type => "application/postscript", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-  $all_rech =~ s/PostScript::Simple generated page/${nachname}_${vorname}/g;
-  print $all_rech;
+my $filename = tiny_string_helpers::string2filename("Rechnung_${nachname}_${rechnungsnr}.pdf");
+print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
+if (!(-d "/tmp/wwwrun")) {
+  mkdir "/tmp" if (!(-d "/tmp"));
+  mkdir "/tmp/wwwrun";
 }
+unlink('/tmp/wwwrun/file.ps');
+$p->output('/tmp/wwwrun/file.ps');
 
-if ($q->user_agent =~ /Windows/ || $q->user_agent =~ /Macintosh/) {
-  my $filename = tiny_string_helpers::string2filename("Rechnung_${nachname}_${rechnungsnr}.pdf");
-  print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-  if (!(-d "/tmp/wwwrun")) {
-    mkdir "/tmp" if (!(-d "/tmp"));
-    mkdir "/tmp/wwwrun";
-  }
-  unlink('/tmp/wwwrun/file.ps');
-  $p->output('/tmp/wwwrun/file.ps');
-
-  if ($^O =~ /linux/ || $^O =~ /darwin/) {
+if ($^O =~ /linux/ || $^O =~ /darwin/) {
 #    warn "Linux oder darwin";
-    system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
-  } elsif ($^O =~ /MSWin32/) {
-    unlink('/tmp/wwwrun/file.pdf');
-    my $gswin=$h->suche_gswin32();
-    $gswin='"'.$gswin.'"';
-    system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
-  } else {
-    die "kein Konvertierungsprogramm ps2pdf gefunden\n";
-  }
-
-  open AUSGABE,"/tmp/wwwrun/file.pdf" or
-    die "konnte Datei nicht konvertieren in pdf\n";
-  binmode AUSGABE;
-  binmode STDOUT;
-  while (my $zeile=<AUSGABE>) {
-    print $zeile;
-  }
-  close AUSGABE;
+  system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
+} elsif ($^O =~ /MSWin32/) {
+  unlink('/tmp/wwwrun/file.pdf');
+  my $gswin=$h->suche_gswin32();
+  $gswin='"'.$gswin.'"';
+  system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
+} else {
+  die "kein Konvertierungsprogramm ps2pdf gefunden\n";
 }
+
+open AUSGABE,"/tmp/wwwrun/file.pdf" or
+  die "konnte Datei nicht konvertieren in pdf\n";
+binmode AUSGABE;
+binmode STDOUT;
+while (my $zeile=<AUSGABE>) {
+  print $zeile;
+}
+close AUSGABE;
 
 if ($speichern eq 'save') {
   # setzt alle Daten in der Datenbank auf Rechnung und speichert die Rechnung

--- a/src/rechnung/ps2html_alt.pl
+++ b/src/rechnung/ps2html_alt.pl
@@ -42,42 +42,36 @@ $l->rechnung_such("RECH,EDI_AUFTRAG,EDI_NUTZ","RECHNUNGSNR='$rech_id'");
 my ($rech,$edi_auf,$edi_nutz)=$l->rechnung_such_next();
 
 if ($rechtyp == 1) {
-  if ($q->user_agent =~ /Windows/) {
-    my $filename = tiny_string_helpers::string2filename("Rechnung_${rech_id}_alt.pdf");
-    print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-    if (!(-d "/tmp/wwwrun")) {
-      mkdir "/tmp" if (!(-d "/tmp"));
-      mkdir "/tmp/wwwrun";
-    }
-    unlink('/tmp/wwwrun/file.ps');
-    open AUSGABE,">/tmp/wwwrun/file.ps" or
-      die "konnte Datei nicht in pdf konvertieren, Schreibfehler für file.ps\n";
-    print AUSGABE $rech;
-    close AUSGABE;
-    if ($^O =~ /linux/) {
-      system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
-    } elsif ($^O =~ /MSWin32/) {
-      unlink('/tmp/wwwrun/file.pdf');
-      my $gswin=$h->suche_gswin32();
-      $gswin='"'.$gswin.'"';
-      system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
-    } else {
-      die "kein Konvertierungsprogramm ps2pdf gefunden\n";
-    }
-
-    open AUSGABE,"/tmp/wwwrun/file.pdf" or
-      die "konnte Datei nicht konvertieren in pdf\n";
-    binmode AUSGABE;
-    binmode STDOUT;
-    while (my $zeile=<AUSGABE>) {
-      print $zeile;
-    }
-    close AUSGABE;
-  } else {
-    my $filename = tiny_string_helpers::string2filename("Rechnung_${rech_id}_alt.ps");
-    print $q->header ( -type => "application/postscript", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-    print $rech;
+  my $filename = tiny_string_helpers::string2filename("Rechnung_${rech_id}_alt.pdf");
+  print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
+  if (!(-d "/tmp/wwwrun")) {
+    mkdir "/tmp" if (!(-d "/tmp"));
+    mkdir "/tmp/wwwrun";
   }
+  unlink('/tmp/wwwrun/file.ps');
+  open AUSGABE,">/tmp/wwwrun/file.ps" or
+    die "konnte Datei nicht in pdf konvertieren, Schreibfehler für file.ps\n";
+  print AUSGABE $rech;
+  close AUSGABE;
+  if ($^O =~ /linux/) {
+    system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
+  } elsif ($^O =~ /MSWin32/) {
+    unlink('/tmp/wwwrun/file.pdf');
+    my $gswin=$h->suche_gswin32();
+    $gswin='"'.$gswin.'"';
+    system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
+  } else {
+    die "kein Konvertierungsprogramm ps2pdf gefunden\n";
+  }
+
+  open AUSGABE,"/tmp/wwwrun/file.pdf" or
+    die "konnte Datei nicht konvertieren in pdf\n";
+  binmode AUSGABE;
+  binmode STDOUT;
+  while (my $zeile=<AUSGABE>) {
+    print $zeile;
+  }
+  close AUSGABE;
 }
 
 if ($rechtyp == 2) {

--- a/src/tools/formulara.pl
+++ b/src/tools/formulara.pl
@@ -263,42 +263,33 @@ $p->text($x1,13.7,'Bogennummer:');
 #$p->text($x1+1.5,10.9,'Zeit');
 
 
-# in Browser schreiben, falls Windows wird PDF erzeugt, sonst Postscript
+# in Browser schreiben als PDF
 my $all_rech=$p->get();
 $all_rech =~ s/Portrait/Landscape/;
-if ($q->user_agent !~ /Windows/) {
-  my $filename = tiny_string_helpers::string2filename("Versichertenbestaetigung_Hilfe_${nachname}.ps");
-  print $q->header ( -type => "application/postscript", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-  $all_rech =~ s/PostScript::Simple generated page/${nachname}_${vorname}/g;
-  print $all_rech;
+my $filename = tiny_string_helpers::string2filename("Versichertenbestaetigung_Hilfe_${nachname}.pdf");
+print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
+if (!(-d "/tmp/wwwrun")) {
+  mkdir "/tmp" if (!(-d "/tmp"));
+  mkdir "/tmp/wwwrun";
+}
+unlink('/tmp/wwwrun/file.ps');
+$p->output('/tmp/wwwrun/file.ps');
+
+if ($^O =~ /linux/) {
+  system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
+} elsif ($^O =~ /MSWin32/) {
+  unlink('/tmp/wwwrun/file.pdf');
+  my $gswin=$h->suche_gswin32();
+  system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
+} else {
+  die "kein Konvertierungsprogramm ps2pdf gefunden\n";
 }
 
-if ($q->user_agent =~ /Windows/) {
-  my $filename = tiny_string_helpers::string2filename("Versichertenbestaetigung_Hilfe_${nachname}.pdf");
-  print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-  if (!(-d "/tmp/wwwrun")) {
-    mkdir "/tmp" if (!(-d "/tmp"));
-    mkdir "/tmp/wwwrun";
-  }
-  unlink('/tmp/wwwrun/file.ps');
-  $p->output('/tmp/wwwrun/file.ps');
-
-  if ($^O =~ /linux/) {
-    system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
-  } elsif ($^O =~ /MSWin32/) {
-    unlink('/tmp/wwwrun/file.pdf');
-    my $gswin=$h->suche_gswin32();
-    system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
-  } else {
-    die "kein Konvertierungsprogramm ps2pdf gefunden\n";
-  }
-
-  open AUSGABE,"/tmp/wwwrun/file.pdf" or
-    die "konnte Datei nicht konvertieren in pdf\n";
-  binmode AUSGABE;
-  binmode STDOUT;
-  while (my $zeile=<AUSGABE>) {
-    print $zeile;
-  }
-  close AUSGABE;
+open AUSGABE,"/tmp/wwwrun/file.pdf" or
+  die "konnte Datei nicht konvertieren in pdf\n";
+binmode AUSGABE;
+binmode STDOUT;
+while (my $zeile=<AUSGABE>) {
+  print $zeile;
 }
+close AUSGABE;

--- a/src/tools/formularc.pl
+++ b/src/tools/formularc.pl
@@ -408,43 +408,35 @@ $p->text($x1+1.5,10.9,'Zeit');
 
 
 
-# in Browser schreiben, falls Windows wird PDF erzeugt, sonst Postscript
+# in Browser schreiben als PDF
 my $all_rech=$p->get();
 $all_rech =~ s/Portrait/Landscape/;
-if ($q->user_agent !~ /Windows/) {
-  my $filename = tiny_string_helpers::string2filename("Versichertenbestaetigung_Hilfe_${nachname}.ps");
-  print $q->header ( -type => "application/postscript", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-  $all_rech =~ s/PostScript::Simple generated page/${nachname}_${vorname}/g;
-  print $all_rech;
+
+my $filename = tiny_string_helpers::string2filename("Versichertenbestaetigung_Hilfe_${nachname}.pdf");
+print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
+if (!(-d "/tmp/wwwrun")) {
+  mkdir "/tmp" if (!(-d "/tmp"));
+  mkdir "/tmp/wwwrun";
+}
+unlink('/tmp/wwwrun/file.ps');
+$p->output('/tmp/wwwrun/file.ps');
+
+if ($^O =~ /linux/) {
+  system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
+} elsif ($^O =~ /MSWin32/) {
+  unlink('/tmp/wwwrun/file.pdf');
+  my $gswin=$h->suche_gswin32();
+  $gswin='"'.$gswin.'"';
+  system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
+} else {
+  die "kein Konvertierungsprogramm ps2pdf gefunden\n";
 }
 
-if ($q->user_agent =~ /Windows/) {
-  my $filename = tiny_string_helpers::string2filename("Versichertenbestaetigung_Hilfe_${nachname}.pdf");
-  print $q->header ( -type => "application/pdf", -expires => "-1d", -content_disposition => "inline; filename=$filename");
-  if (!(-d "/tmp/wwwrun")) {
-    mkdir "/tmp" if (!(-d "/tmp"));
-    mkdir "/tmp/wwwrun";
-  }
-  unlink('/tmp/wwwrun/file.ps');
-  $p->output('/tmp/wwwrun/file.ps');
-
-  if ($^O =~ /linux/) {
-    system('ps2pdf /tmp/wwwrun/file.ps /tmp/wwwrun/file.pdf');
-  } elsif ($^O =~ /MSWin32/) {
-    unlink('/tmp/wwwrun/file.pdf');
-    my $gswin=$h->suche_gswin32();
-    $gswin='"'.$gswin.'"';
-    system("$gswin -q -dCompatibilityLevel=1.2 -dSAFER -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -sOutputFile=/tmp/wwwrun/file.pdf -c .setpdfwrite -f /tmp/wwwrun/file.ps");
-  } else {
-    die "kein Konvertierungsprogramm ps2pdf gefunden\n";
-  }
-
-  open AUSGABE,"/tmp/wwwrun/file.pdf" or
-    die "konnte Datei nicht konvertieren in pdf\n";
-  binmode AUSGABE;
-  binmode STDOUT;
-  while (my $zeile=<AUSGABE>) {
-    print $zeile;
-  }
-  close AUSGABE;
+open AUSGABE,"/tmp/wwwrun/file.pdf" or
+  die "konnte Datei nicht konvertieren in pdf\n";
+binmode AUSGABE;
+binmode STDOUT;
+while (my $zeile=<AUSGABE>) {
+  print $zeile;
 }
+close AUSGABE;

--- a/src/tools/key.html
+++ b/src/tools/key.html
@@ -35,7 +35,7 @@
 		    <td><b>Dateiname der Schlüsseldatei</b></td>
 		  </tr>
 		  <tr>
-		    <td  style="font-size: small">Die Schlüsseldateien müssen vorher aus dem <a href="javascript:oeffnen('http://www.itsg.de/%28S%285rxq1l45011uub45y5zfhb55%29%29/tc_keys_leistungserbringerverfahren.ITSG')">Internet</a> geladen werden</td>
+		    <td  style="font-size: small">Die Schlüsseldateien müssen vorher aus dem <a href="javascript:oeffnen('http://www.itsg.de/oeffentliche-services/trust-center/oeffentliche-schluesselverzeichnisse-le/')">Internet</a> geladen werden</td>
 		  </tr>
 		  <tr>
 		    <td><input type='file' name='datei' size='80'></td>


### PR DESCRIPTION
- 0734b19: ITSG has restructured their website, so we need to update our hyperlink to the public key directory (i.e. the place where you can download annahme-sha256.key )
- ad804ea: Eliminate dependency from Mozilla::CA which does not exist in Debian / Ubuntu repositories, instead relying on Net::SSLeay. By doing so, we use the system-wide certificate store instead of a separate Mozilla-maintained certificate collection, which should also improve security in case of rogue CAs whose certificates get revoked.
- a280c29: Remove browser OS detection, deliver PDF regardless of the OS used on the client. Background: Mozilla deliberately removed the NPAPI from Firefox 52 onwards, therefore using mozplugger to render PostScript output in Firefox is no longer an option. However, most (all?) modern browsers are able to render PDF files using PDF.js.